### PR TITLE
Add Microsoft Store installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,29 @@
 ![OS - Windows 11](https://img.shields.io/badge/OS-Windows_11-09e0fe?style=for-the-badge)
 ![OS - Windows 10 1809+](https://img.shields.io/badge/OS-Windows_10_2004%2B-00adef?style=for-the-badge)
 
+<a href="https://apps.microsoft.com/detail/9P8ZCW9FTL0T">
+  <img src="https://get.microsoft.com/images/en-us%20dark.svg" alt="Download from the Microsoft Store" width="200">
+</a>
+
 ## About
 This app allows you to connect your Home Assistant instance with SteamVR, to learn more visit the [integration repo](https://github.com/Antoni-Czaplicki/SteamVR.HA).
 
-## Installation instructions
-- Option 1
-Compile application from the source code and install it by yourself
+## Installation
 
-- Option 2
-1. Download compiled app package attached to the [latest release](https://github.com/Antoni-Czaplicki/SteamVR.HA-Agent/releases/latest)
-2. Install certificate (the app is using self-signed cert for now so you have to add it to trusted by your machine)
-`Right mouse click on downloaded file` -> `Properties` -> `Digital Signatures` -> `The first cert "antek"` -> `View Certificate` -> `Install Certificate` -> `Local Machine` -> `Next` -> `Place all certificates in the following store` -> `Browse` -> `Trusted People` -> `OK` -> `Next` -> `Finish`
-3. Double click on the app package to start installation
+### Microsoft Store (recommended)
+
+Install [Home Assistant Agent for SteamVR from the Microsoft Store](https://apps.microsoft.com/detail/9P8ZCW9FTL0T) to receive trusted, automatic updates.
+
+### GitHub release
+
+1. Download the compiled app package attached to the [latest release](https://github.com/Antoni-Czaplicki/SteamVR.HA-Agent/releases/latest).
+2. Install the self-signed certificate included with the package:
+   `Right-click the downloaded file` -> `Properties` -> `Digital Signatures` -> `antek` -> `View Certificate` -> `Install Certificate` -> `Local Machine` -> `Next` -> `Place all certificates in the following store` -> `Browse` -> `Trusted People` -> `OK` -> `Next` -> `Finish`.
+3. Double-click the app package to start the installation.
+
+### Build from source
+
+Compile the application from the source code and install it locally.
 
 ## Screenshots
 ![image](https://github.com/Antoni-Czaplicki/SteamVR.HA-Agent/assets/56671347/e431afe0-0b40-48d0-a916-124767b454e5)


### PR DESCRIPTION
## What changed

- Add the official Microsoft Store download badge linked to product `9P8ZCW9FTL0T`
- Make Microsoft Store installation the recommended path
- Keep GitHub release and source-build instructions as alternatives

## Why

Home Assistant Agent for SteamVR is now published in the Microsoft Store. The README should direct users to the trusted Store package and its automatic update path instead of presenting self-signed packages as the primary installation method.
